### PR TITLE
Add testing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Sets the options used to determine the outcome of `MockConnection.connect` and
   stderr that a command should give. All three options is optional and have the
   following defaults: code=0, stdout='', stderr=''. The default for the option
   is `{}`
+* `throwIfMockNotDefined` (boolean) - Throw an error if exec is called
+  on a command that doesn't have a mock output defined
 
 Example
 ```javascript
@@ -38,6 +40,11 @@ ssh.setMockOptions({
   }
 })
 ```
+
+#### `.setOfflineMode(true)`
+Will prevent any real connections from being made, causing an error to
+be throwin instead. Useful when in test mode to make sure tests don't
+trigger connections to remote servers.
 
 ### Connection
 #### `Connection.connect()`

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -92,7 +92,7 @@ MockConnection.prototype.connect = Bluebird.method(function connect() {
 });
 
 MockConnection.prototype.exec = function exec(commands) {
-  _this = this;
+  var _this = this;
   var stdout = '';
   var stderr = '';
   return Bluebird.each(commands, function(command) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -116,6 +116,9 @@ MockConnection.prototype.exec = function exec(commands) {
       return Bluebird.resolve(commandOptions.code || 0);
 
     } else {
+      if (_this.mockOptions.throwIfMockNotDefined) {
+        throw new Error("Mock for '" + command + "' not defined");
+      }
       return ['', ''];
     }
   })

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -2,11 +2,15 @@ var Bluebird = require('bluebird');
 var connection = require('./connection');
 var errors = require('./errors');
 
-var mockOptions = {};
+var mockOptions = {},
+    offlineMode = false;
 
 module.exports.errors = errors;
 
 module.exports.connect = function connect(options) {
+  if (offlineMode) {
+    throw new Error("Real connections to " + options.host + " are not allowed in offline mode");
+  }
   return new connection.Connection(options).connect();
 };
 
@@ -16,4 +20,8 @@ module.exports.connectMock = function connectMock(options) {
 
 module.exports.setMockOptions = function setMockOptions(options) {
   mockOptions = options;
+};
+
+module.exports.setOfflineMode = function setOfflineMode(value) {
+ offlineMode = !!value;
 };


### PR DESCRIPTION
Add flags to:
- throw an error if a real ssh connection is made
- an endpoint is used on a mockConnection without a mock defined
