### PR TITLE
Add end method in Connection class

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -72,6 +72,12 @@ Connection.prototype = {
     });
   },
 
+  end: function end() {
+    var _this = this;
+    _this._log('closing connection');
+    _this._connection.end();
+  },
+
   toString: function toString() {
     return this.username + '@' + this.host;
   },


### PR DESCRIPTION
Sometimes ssh connection hanged and program will not stop, I try to add end method in Connection class，so i can use bluebird's `.timeout()` method and this end method to close hanged connection. example:

```
var sshConnection;
ssh.connect(hostOption)
    .then(function (connection) {
        sshConnection  = connection;
        return connection.exec(RenderedCommandList);
    })
    .timeout(10000)
    .spread(function (stdout, stderr) {
        //pass;
    }
    .catch(Promise.TimeoutError, function (e) {
         sshConnection.end();
         //pass;
    .}
```
